### PR TITLE
Handle wrapping with coloured strings better

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: rust:1
+    steps:
+      - checkout
+      - run:
+          name: Version information
+          command: rustc --version; rustup --version; cargo --version
+      - run:
+          name: Calculate dependencies
+          command: cargo generate-lockfile --verbose
+      - restore_cache:
+          keys:
+            - v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Build all targets
+          command: cargo build --all-targets --verbose
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target/debug/.fingerprint
+            - target/debug/build
+            - target/debug/deps
+          key: v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Run all tests
+          command: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,14 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,7 +94,6 @@ version = "0.2.1"
 dependencies = [
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -272,7 +263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e48d85528df61dc964aa43c5f6ca681a19cfa74939b2348d204bd08a981f2fb0"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc0a60679001b62fb628c4da80e574b9645ab4646056d7c9018885efffe45533"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "litime"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.2.1"
 authors = ["Axel Örn Sigurðsson <axel@absalon.is>"]
 
 [dependencies]
-colored = "1.6"
 textwrap = "0.10"
 rand = "0.5.5"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litime"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Axel Örn Sigurðsson <axel@absalon.is>"]
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use clap::{App, AppSettings, Arg};
 use regex::Regex;
 
 use minute::get_minute;
-use wrapper::wrap_minute;
 
 mod minute;
 mod wrapper;
@@ -50,8 +49,7 @@ fn main() {
     let width = value_t!(matches, "width", usize).unwrap_or_else(|e| e.exit());
 
     let minute = get_minute(timestamp);
-    let output = wrap_minute(minute, width);
-    print!("{}", output);
+    print!("{}", minute.wrapped(width));
 }
 
 fn is_timestamp(val: String) -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 extern crate chrono;
 #[macro_use]
 extern crate clap;
-extern crate colored;
 extern crate rand;
 extern crate regex;
 extern crate textwrap;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,13 @@ extern crate textwrap;
 
 use chrono::prelude::*;
 use clap::{App, AppSettings, Arg};
-use colored::*;
 use regex::Regex;
-use textwrap::wrap_iter;
 
 use minute::get_minute;
+use wrapper::wrap_minute;
 
 mod minute;
+mod wrapper;
 
 fn main() {
     let matches = App::new("Litime")
@@ -51,21 +51,7 @@ fn main() {
     let width = value_t!(matches, "width", usize).unwrap_or_else(|e| e.exit());
 
     let minute = get_minute(timestamp);
-    let result = format!(
-        "{}{}{}",
-        minute.start.bright_black(),
-        minute.time.red(),
-        minute.end.bright_black()
-    );
-
-    let mut output = String::from("\n  \" ");
-
-    for line in wrap_iter(&result, width) {
-        output.push_str(&line);
-        output.push_str("\n    ");
-    }
-    output.push('\n');
-    output.push_str(format!("        {} - {}\n", minute.author, minute.title).as_str());
+    let output = wrap_minute(minute, width);
     print!("{}", output);
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,0 +1,183 @@
+use textwrap::Wrapper;
+
+use minute::Minute;
+
+static INITIAL_INDENT: &'static str = "  \" ";
+static SUBSEQUENT_INDENT: &'static str = "    ";
+const INDENT_LEN: usize = 4;
+
+static BLACK: &'static str = "\u{1b}[90m";
+static RED: &'static str = "\u{1b}[31m";
+static WHITE: &'static str = "\u{1b}[97m";
+
+pub fn wrap_minute(minute: Minute, width: usize) -> String {
+    let start_len = minute.start.len();
+    let time_len = minute.time.len();
+
+    let full = format!("{}{}{}", minute.start, minute.time, minute.end);
+
+    let wrapper = Wrapper::new(width)
+        .initial_indent(INITIAL_INDENT)
+        .subsequent_indent(SUBSEQUENT_INDENT);
+
+    let wrapped_lines = wrapper.wrap(full.as_str());
+
+    let mut output = String::from(BLACK);
+
+    let mut count = start_len;
+    let mut red = false;
+    let mut black = false;
+
+    for line in wrapped_lines {
+        output.push('\n');
+        let line_len = line.len() - INDENT_LEN;
+
+        if line_len < count {
+            // If the count for the current part of the quote is higher than the current line, just
+            // continue on
+            count -= line_len;
+            output.push_str(&line);
+        } else if !red {
+            // The current line is longer than the current part and we haven't started the red
+            // section, so insert the code for red
+            red = true;
+
+            let mut s = String::from(line);
+
+            s.insert_str(count + INDENT_LEN, RED);
+            count += time_len;
+
+            // Check if the red section is not long enough to be split into a different line
+            if count < line_len {
+                black = true;
+                s.insert_str(count + RED.len() + INDENT_LEN, BLACK);
+            } else {
+                count -= line_len;
+            }
+
+            output.push_str(s.as_str());
+        } else if !black {
+            // End the red section
+            black = true;
+
+            let mut s = String::from(line);
+
+            s.insert_str(count + INDENT_LEN, BLACK);
+            count += time_len;
+
+            output.push_str(s.as_str());
+        } else {
+            // Just keep adding the final lines
+            output.push_str(&line);
+        }
+
+        if count > 0 {
+            count -= 1; // Account for spaces that would be between the words in different lines
+        }
+    }
+
+    output.push_str(
+        format!(
+            "\n\n{}{}{}{} - {}\n",
+            WHITE, SUBSEQUENT_INDENT, SUBSEQUENT_INDENT, minute.author, minute.title
+        ).as_str(),
+    );
+
+    output
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn wrapped_quote() {
+        let minute = Minute {
+            start: "black black black ",
+            time: "red red red red",
+            end: " black black black ",
+            author: "author",
+            title: "title",
+        };
+
+        let wrapped = wrap_minute(minute, 20);
+        let expected = [
+            String::from(BLACK),
+            String::from("  \" black black"),
+            format!("    black {}red red", RED),
+            format!("    red red{} black", BLACK),
+            String::from("    black black "),
+            String::new(),
+            format!("{}        author - title", WHITE),
+            String::new(),
+        ].join("\n");
+
+        assert_eq!(wrapped, expected);
+    }
+
+    #[test]
+    fn short_quote() {
+        let minute = Minute {
+            start: "foo ",
+            time: "bar",
+            end: " baz",
+            author: "author",
+            title: "title",
+        };
+
+        let wrapped = wrap_minute(minute, 50);
+        let expected = [
+            String::from(BLACK),
+            format!("  \" foo {}bar{} baz", RED, BLACK),
+            String::new(),
+            format!("{}        author - title", WHITE),
+            String::new(),
+        ].join("\n");
+
+        assert_eq!(wrapped, expected);
+    }
+
+    #[test]
+    fn no_start() {
+        let minute = Minute {
+            start: "",
+            time: "bar",
+            end: " baz",
+            author: "author",
+            title: "title",
+        };
+
+        let wrapped = wrap_minute(minute, 50);
+        let expected = [
+            String::from(BLACK),
+            format!("  \" {}bar{} baz", RED, BLACK),
+            String::new(),
+            format!("{}        author - title", WHITE),
+            String::new(),
+        ].join("\n");
+
+        assert_eq!(wrapped, expected);
+    }
+
+    #[test]
+    fn no_end() {
+        let minute = Minute {
+            start: "foo ",
+            time: "bar",
+            end: "",
+            author: "author",
+            title: "title",
+        };
+
+        let wrapped = wrap_minute(minute, 50);
+        let expected = [
+            String::from(BLACK),
+            format!("  \" foo {}bar", RED),
+            String::new(),
+            format!("{}        author - title", WHITE),
+            String::new(),
+        ].join("\n");
+
+        assert_eq!(wrapped, expected);
+    }
+}

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -10,80 +10,82 @@ static BLACK: &'static str = "\u{1b}[90m";
 static RED: &'static str = "\u{1b}[31m";
 static WHITE: &'static str = "\u{1b}[97m";
 
-pub fn wrap_minute(minute: Minute, width: usize) -> String {
-    let start_len = minute.start.len();
-    let time_len = minute.time.len();
+impl Minute {
+    pub fn wrapped(&self, width: usize) -> String {
+        let start_len = self.start.len();
+        let time_len = self.time.len();
 
-    let full = format!("{}{}{}", minute.start, minute.time, minute.end);
+        let full = format!("{}{}{}", self.start, self.time, self.end);
 
-    let wrapper = Wrapper::new(width)
-        .initial_indent(INITIAL_INDENT)
-        .subsequent_indent(SUBSEQUENT_INDENT);
+        let wrapper = Wrapper::new(width)
+            .initial_indent(INITIAL_INDENT)
+            .subsequent_indent(SUBSEQUENT_INDENT);
 
-    let wrapped_lines = wrapper.wrap(full.as_str());
+        let wrapped_lines = wrapper.wrap(full.as_str());
 
-    let mut output = String::from(BLACK);
+        let mut output = String::from(BLACK);
 
-    let mut count = start_len;
-    let mut red = false;
-    let mut black = false;
+        let mut count = start_len;
+        let mut red = false;
+        let mut black = false;
 
-    for line in wrapped_lines {
-        output.push('\n');
-        let line_len = line.len() - INDENT_LEN;
+        for line in wrapped_lines {
+            output.push('\n');
+            let line_len = line.len() - INDENT_LEN;
 
-        if line_len < count {
-            // If the count for the current part of the quote is higher than the current line, just
-            // continue on
-            count -= line_len;
-            output.push_str(&line);
-        } else if !red {
-            // The current line is longer than the current part and we haven't started the red
-            // section, so insert the code for red
-            red = true;
-
-            let mut s = String::from(line);
-
-            s.insert_str(count + INDENT_LEN, RED);
-            count += time_len;
-
-            // Check if the red section is not long enough to be split into a different line
-            if count < line_len {
-                black = true;
-                s.insert_str(count + RED.len() + INDENT_LEN, BLACK);
-            } else {
+            if line_len < count {
+                // If the count for the current part of the quote is higher than the current line, just
+                // continue on
                 count -= line_len;
+                output.push_str(&line);
+            } else if !red {
+                // The current line is longer than the current part and we haven't started the red
+                // section, so insert the code for red
+                red = true;
+
+                let mut s = String::from(line);
+
+                s.insert_str(count + INDENT_LEN, RED);
+                count += time_len;
+
+                // Check if the red section is not long enough to be split into a different line
+                if count < line_len {
+                    black = true;
+                    s.insert_str(count + RED.len() + INDENT_LEN, BLACK);
+                } else {
+                    count -= line_len;
+                }
+
+                output.push_str(s.as_str());
+            } else if !black {
+                // End the red section
+                black = true;
+
+                let mut s = String::from(line);
+
+                s.insert_str(count + INDENT_LEN, BLACK);
+                count += time_len;
+
+                output.push_str(s.as_str());
+            } else {
+                // Just keep adding the final lines
+                output.push_str(&line);
             }
 
-            output.push_str(s.as_str());
-        } else if !black {
-            // End the red section
-            black = true;
-
-            let mut s = String::from(line);
-
-            s.insert_str(count + INDENT_LEN, BLACK);
-            count += time_len;
-
-            output.push_str(s.as_str());
-        } else {
-            // Just keep adding the final lines
-            output.push_str(&line);
+            if count > 0 {
+                count -= 1; // Account for spaces that would be between the words in different lines
+            }
         }
 
-        if count > 0 {
-            count -= 1; // Account for spaces that would be between the words in different lines
-        }
+        output.push_str(
+            format!(
+                "\n\n{}{}{}{} - {}\n",
+                WHITE, SUBSEQUENT_INDENT, SUBSEQUENT_INDENT, self.author, self.title
+            ).as_str(),
+        );
+
+        output
     }
-
-    output.push_str(
-        format!(
-            "\n\n{}{}{}{} - {}\n",
-            WHITE, SUBSEQUENT_INDENT, SUBSEQUENT_INDENT, minute.author, minute.title
-        ).as_str(),
-    );
-
-    output
 }
 
 #[cfg(test)]
@@ -100,7 +102,7 @@ mod test {
             title: "title",
         };
 
-        let wrapped = wrap_minute(minute, 20);
+        let wrapped = minute.wrapped(20);
         let expected = [
             String::from(BLACK),
             String::from("  \" black black"),
@@ -125,7 +127,7 @@ mod test {
             title: "title",
         };
 
-        let wrapped = wrap_minute(minute, 50);
+        let wrapped = minute.wrapped(50);
         let expected = [
             String::from(BLACK),
             format!("  \" foo {}bar{} baz", RED, BLACK),
@@ -147,7 +149,7 @@ mod test {
             title: "title",
         };
 
-        let wrapped = wrap_minute(minute, 50);
+        let wrapped = minute.wrapped(50);
         let expected = [
             String::from(BLACK),
             format!("  \" {}bar{} baz", RED, BLACK),
@@ -169,7 +171,7 @@ mod test {
             title: "title",
         };
 
-        let wrapped = wrap_minute(minute, 50);
+        let wrapped = minute.wrapped(50);
         let expected = [
             String::from(BLACK),
             format!("  \" foo {}bar", RED),


### PR DESCRIPTION
The source code for the wrapping function isn't ideal, but it's got simple tests and does exactly what I want it to do. It can be refactored to be nicer later.

## Examples

### Before
![image](https://user-images.githubusercontent.com/3537289/46037680-24bc8080-c109-11e8-9217-6f8a397c569b.png)

### After
![image](https://user-images.githubusercontent.com/3537289/46037688-28e89e00-c109-11e8-8a29-890073453a56.png)

### Before
![image](https://user-images.githubusercontent.com/3537289/46037696-300fac00-c109-11e8-9e05-1d2ba5c01484.png)

### After 
![image](https://user-images.githubusercontent.com/3537289/46037702-36058d00-c109-11e8-81a6-5631a6934a6e.png)

Closes \#1