### PR TITLE
Simplify the really complex wrapping function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "litime"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litime"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Axel Örn Sigurðsson <axel@absalon.is>"]
 description = "A command line tool to display the current time ish with a literature quote"
 repository = "https://github.com/ikornaselur/litime"

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -5,93 +5,32 @@ use minute::Minute;
 static INITIAL_INDENT: &'static str = "  \" ";
 static SUBSEQUENT_INDENT: &'static str = "    ";
 static FOOTER_INDENT: &'static str = "        ";
-const INDENT_LEN: usize = 4;
 
-static BLACK: &'static str = "\u{1b}[90m";
-static RED: &'static str = "\u{1b}[31m";
-static WHITE: &'static str = "\u{1b}[97m";
-static RESET: &'static str = "\u{1b}[0m";
+static RESET: &'static str = "\u{1b}[0m"; // 0x00
+static WHITE: &'static str = "\u{1b}[97m"; // 0x01
+static BLACK: &'static str = "\u{1b}[90m"; // 0x02
+static RED: &'static str = "\u{1b}[31m"; // 0x03
 
 impl Minute {
     pub fn wrapped(&self, width: usize) -> String {
-        let start_len = self.start.len();
-        let time_len = self.time.len();
+        let quote = format!("\x02{}\x03{}\x02{}\x00", self.start, self.time, self.end);
+        let footer = format!("\x01{} – {}\x00", self.author, self.title);
 
-        let full = format!("{}{}{}", self.start, self.time, self.end);
-
-        let wrapper = Wrapper::new(width)
+        let quote_wrapper = Wrapper::new(width)
             .initial_indent(INITIAL_INDENT)
             .subsequent_indent(SUBSEQUENT_INDENT);
-
-        let wrapped_lines = wrapper.wrap(full.as_str());
-
-        let mut output = String::from(BLACK);
-
-        let mut count = start_len;
-        let mut red = false;
-        let mut black = false;
-
-        for line in wrapped_lines {
-            output.push('\n');
-            let line_len = line.len() - INDENT_LEN;
-
-            let mut string = String::from(line);
-
-            if line_len < count {
-                // If the count for the current part of the quote is higher than the current line, just
-                // continue on
-                count -= line_len;
-                output.push_str(string.as_str());
-            } else if !red {
-                // The current line is longer than the current part and we haven't started the red
-                // section, so insert the code for red
-                red = true;
-
-                string.insert_str(count + INDENT_LEN, RED);
-                count += time_len;
-
-                // Check if the red section is not long enough to be split into a different line
-                if count < line_len {
-                    black = true;
-                    string.insert_str(count + RED.len() + INDENT_LEN, BLACK);
-                } else {
-                    count -= line_len;
-                }
-
-                output.push_str(string.as_str());
-            } else if !black {
-                // End the red section
-                black = true;
-
-                string.insert_str(count + INDENT_LEN, BLACK);
-                count += time_len;
-
-                output.push_str(string.as_str());
-            } else {
-                // Just keep adding the final lines
-                output.push_str(string.as_str());
-            }
-
-            // Account for spaces that would be between the words in different lines, but if a line
-            // ends with a dash, there was no space between the words
-            if count > 0 && !string.ends_with('-') {
-                count -= 1;
-            }
-        }
-        output.push_str(format!("\n{}\n", WHITE).as_str());
-
         let footer_wrapper = Wrapper::new(width)
             .initial_indent(FOOTER_INDENT)
             .subsequent_indent(FOOTER_INDENT);
 
-        let footer = format!("{} - {}", self.author, self.title);
-        let footer_lines = footer_wrapper.wrap(footer.as_str());
+        let quote = quote_wrapper.wrap(quote.as_str()).join("\n");
+        let footer = footer_wrapper.wrap(footer.as_str()).join("\n");
 
-        output.push_str(footer_lines.join("\n").as_str());
-
-        output.push_str(format!("\n{}", RESET).as_str());
-
-        output
+        format!("\n{}\n\n{}\n", quote, footer)
+            .replace('\x00', RESET)
+            .replace('\x01', WHITE)
+            .replace('\x02', BLACK)
+            .replace('\x03', RED)
     }
 }
 
@@ -104,22 +43,19 @@ mod test {
         let minute = Minute {
             start: "black black black ",
             time: "red red red red",
-            end: " black black black ",
+            end: " black black black",
             author: "author",
             title: "title",
         };
 
         let wrapped = minute.wrapped(20);
         let expected = [
-            String::from(BLACK),
-            String::from("  \" black black"),
+            format!("\n  \" {}black black", BLACK),
             format!("    black {}red red", RED),
             format!("    red red{} black", BLACK),
-            String::from("    black black "),
-            String::from(WHITE),
-            String::from("        author -"),
-            String::from("        title"),
-            String::from(RESET),
+            format!("    black black{}\n", RESET),
+            format!("        {}author –", WHITE),
+            format!("        title{}\n", RESET),
         ].join("\n");
 
         assert_eq!(wrapped, expected);
@@ -137,11 +73,8 @@ mod test {
 
         let wrapped = minute.wrapped(50);
         let expected = [
-            String::from(BLACK),
-            format!("  \" foo {}bar{} baz", RED, BLACK),
-            String::from(WHITE),
-            String::from("        author - title"),
-            String::from(RESET),
+            format!("\n  \" {}foo {}bar{} baz{}\n", BLACK, RED, BLACK, RESET),
+            format!("        {}author – title{}\n", WHITE, RESET),
         ].join("\n");
 
         assert_eq!(wrapped, expected);
@@ -159,11 +92,8 @@ mod test {
 
         let wrapped = minute.wrapped(50);
         let expected = [
-            String::from(BLACK),
-            format!("  \" {}bar{} baz", RED, BLACK),
-            String::from(WHITE),
-            String::from("        author - title"),
-            String::from(RESET),
+            format!("\n  \" {}{}bar{} baz{}\n", BLACK, RED, BLACK, RESET),
+            format!("        {}author – title{}\n", WHITE, RESET),
         ].join("\n");
 
         assert_eq!(wrapped, expected);
@@ -181,11 +111,8 @@ mod test {
 
         let wrapped = minute.wrapped(50);
         let expected = [
-            String::from(BLACK),
-            format!("  \" foo {}bar", RED),
-            String::from(WHITE),
-            String::from("        author - title"),
-            String::from(RESET),
+            format!("\n  \" {}foo {}bar{}{}\n", BLACK, RED, BLACK, RESET),
+            format!("        {}author – title{}\n", WHITE, RESET),
         ].join("\n");
 
         assert_eq!(wrapped, expected);
@@ -203,18 +130,21 @@ mod test {
 
         let wrapped = minute.wrapped(50);
         let expected = [
-            String::from(BLACK),
-            String::from("  \" At 10.15 Arlena departed from her rondezvous,"),
+            format!(
+                "\n  \" {}At 10.15 Arlena departed from her rondezvous,",
+                BLACK
+            ),
             String::from("    a minute or two later Patrick Redfern came"),
             String::from("    down and registered surprise, annoyance, etc."),
             String::from("    Christine\'s task was easy enough. Keeping her"),
             String::from("    own watch concealed she asked Linda at twenty-"),
             String::from("    five past eleven what time it was."),
             String::from("    Linda looked at her watch and replied that it"),
-            format!("    was a {}quarter to twelve{}.", RED, BLACK),
-            String::from(WHITE),
-            String::from("        Agatha Christie - Evil under the Sun"),
-            String::from(RESET),
+            format!("    was a {}quarter to twelve{}.{}\n", RED, BLACK, RESET),
+            format!(
+                "        {}Agatha Christie – Evil under the Sun{}\n",
+                WHITE, RESET
+            ),
         ].join("\n");
 
         assert_eq!(wrapped, expected);
@@ -232,16 +162,13 @@ mod test {
 
         let wrapped = minute.wrapped(30);
         let expected = [
-            String::from(BLACK),
-            String::from("  \" And the first stop had"),
+            format!("\n  \" {}And the first stop had", BLACK),
             format!("    been at {}1.16pm{} which was", RED, BLACK),
-            String::from("    17 minutes later."),
-            String::from(WHITE),
-            String::from("        Mark Haddon - The"),
+            format!("    17 minutes later.{}\n", RESET),
+            format!("        {}Mark Haddon – The", WHITE),
             String::from("        Curious Incident of"),
             String::from("        the Dog in the Night-"),
-            String::from("        Time"),
-            String::from(RESET),
+            format!("        Time{}\n", RESET),
         ].join("\n");
 
         assert_eq!(wrapped, expected);


### PR DESCRIPTION
Rather than counting the number of characters like before, simply insert one byte placeholders for the colour escapes. Then wrap as normally and replace the placeholders at the end.