### PR TITLE
Add build scripts for Macos, Linux and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 A simple tool to display the current time with a quote from literature.
 
-### Example
+## Example
 
 _Running litime on shell startup_
 ![example](example.png)
 
 
-### Attributions
-Built on top of the data from [JohannesNE/literature-clock](https://github.com/JohannesNE/literature-clock). See `script.py` for quick and dirty script to update.
+## Attributions
+### Source of quotes
+Built on top of the data from
+[JohannesNE/literature-clock](https://github.com/JohannesNE/literature-clock).
+See `script.py` for quick and dirty script to update.
+
+### Build script
+Scripts for building artifacts for Macos, Linux and Windows are built heavily
+on
+[rust-build/rust-build.action](https://github.com/rust-build/rust-build.action)

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:1.58-alpine
+
+# Add regular dependencies
+RUN apk add --no-cache curl jq git build-base bash zip
+
+# Add windows dependencies
+RUN apk add --no-cache mingw-w64-gcc
+
+# Add apple dependencies
+RUN apk add --no-cache clang cmake libxml2-dev openssl-dev fts-dev bsd-compat-headers xz
+RUN git clone https://github.com/tpoechtrager/osxcross /opt/osxcross
+RUN curl -Lo /opt/osxcross/tarballs/MacOSX10.10.sdk.tar.xz "https://s3.dockerproject.org/darwin/v2/MacOSX10.10.sdk.tar.xz"
+RUN ["/bin/bash", "-c", "cd /opt/osxcross && UNATTENDED=yes OSX_VERSION_MIN=10.8 ./build.sh"]
+
+ADD entrypoint.sh ./entrypoint.sh
+ADD build.sh ./build.sh
+
+RUN chmod +x /entrypoint.sh /build.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+info() {
+    echo "::info $*" >&2
+}
+
+error() {
+    echo "::error file=build.sh:: $*" >&2
+}
+
+set -eu -o pipefail
+
+crash() {
+    error "Command exited with non-zero exit code"
+    exit 1
+}
+
+trap 'crash' ERR
+OUTPUT_DIR="$1"
+RUSTTARGET="$2"
+
+info "Installing additional linkers"
+case ${RUSTTARGET} in
+    "x86_64-pc-windows-gnu") ;;
+
+    "x86_64-unknown-linux-musl") ;;
+
+    "x86_64-apple-darwin")
+        export CC=/opt/osxcross/target/bin/o64-clang
+        export CXX=/opt/osxcross/target/bin/o64-clang++
+        export PATH="/opt/osxcross/target/bin:$PATH"
+        export LIBZ_SYS_STATIC=1
+        mkdir -p /.cargo
+        cat > /.cargo/config.toml << EOF
+[target.x86_64-apple-darwin]
+linker = "/opt/osxcross/target/bin/x86_64-apple-darwin14-clang"
+ar = "/opt/osxcross/target/bin/x86_64-apple-darwin14-ar"
+EOF
+        ;;
+
+    *)
+        error "${RUSTTARGET} is not supported"
+        exit 1
+        ;;
+esac
+
+info "Setting up toolchain"
+TOOLCHAIN_VERSION="${TOOLCHAIN_VERSION:-""}"
+if [ "$TOOLCHAIN_VERSION" != "" ]; then
+    rustup default "$TOOLCHAIN_VERSION" >&2
+fi
+rustup target add "$RUSTTARGET" >&2
+
+BINARIES="$(cargo read-manifest | jq -r ".targets[] | select(.kind[] | contains(\"bin\")) | .name")"
+
+OUTPUT_LIST=""
+for BINARY in $BINARIES; do
+    info "Building $BINARY..."
+
+    OPENSSL_LIB_DIR=/usr/lib OPENSSL_INCLUDE_DIR=/usr/include/openssl CARGO_TARGET_DIR="./target" cargo build --release --target "$RUSTTARGET" --bin "$BINARY" >&2
+    OUTPUT=$(find "target/${RUSTTARGET}/release/" -maxdepth 1 -type f -executable \( -name "${BINARY}" -o -name "${BINARY}.exe" \) -print0 | xargs -0)
+
+    info "$OUTPUT"
+
+    if [ "$OUTPUT" = "" ]; then
+        error "Unable to find output"
+        exit 1
+    fi
+
+    info "Minifying ${OUTPUT}..."
+
+    info "Stripping..."
+    strip "${OUTPUT}" >&2 || info "Strip failed."
+    info "File stripped successfully."
+
+    info "Saving $OUTPUT..."
+
+  # shellcheck disable=SC2086
+  mv $OUTPUT "$OUTPUT_DIR" || error "Unable to copy binary"
+
+  for f in $OUTPUT; do
+      OUTPUT_LIST="$OUTPUT_LIST $(basename "$f")"
+  done
+done
+echo "$OUTPUT_LIST"

--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ -z "${CMD_PATH+x}" ]; then
+  export CMD_PATH=""
+fi
+
+OUTPUT_DIR="/output"
+PROJECT_ROOT="/rust/build/litime"
+cd "$PROJECT_ROOT"
+
+# Build Apple
+APPLE_OUT="$OUTPUT_DIR/apple"
+mkdir -p "$APPLE_OUT"
+if ! FILE_LIST=$(/build.sh "$APPLE_OUT" "x86_64-apple-darwin"); then
+  echo "::error file=entrypoint.sh::Build failed" >&2
+  exit 1
+fi
+
+# Build Linux
+LINUX_OUT="$OUTPUT_DIR/linux"
+mkdir -p "$LINUX_OUT"
+if ! FILE_LIST=$(/build.sh "$LINUX_OUT" "x86_64-unknown-linux-musl"); then
+  echo "::error file=entrypoint.sh::Build failed" >&2
+  exit 1
+fi
+
+# Build Windows
+WINDOWS_OUT="$OUTPUT_DIR/windows"
+mkdir -p "$WINDOWS_OUT"
+if ! FILE_LIST=$(/build.sh "$WINDOWS_OUT" "x86_64-pc-windows-gnu"); then
+  echo "::error file=entrypoint.sh::Build failed" >&2
+  exit 1
+fi


### PR DESCRIPTION
Scripts were customised to be run locally and produce just the executable binaries.