### PR TITLE
Replace rand with a pseudo random picker based on current timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,12 +74,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "clap"
 version = "4.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,17 +132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "getrandom"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,7 +175,6 @@ dependencies = [
  "anyhow",
  "clap",
  "pretty_assertions",
- "rand",
  "serde",
  "serde_json",
  "termsize",
@@ -214,12 +196,6 @@ name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "pretty_assertions"
@@ -247,36 +223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -445,12 +391,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ include = [
 
 [dependencies]
 textwrap = "0.16"
-rand = "0.8"
 clap = { version = "4", features = ["derive"] }
 termsize = "0.1"
 time = { version = "0.3", features = ["local-offset", "parsing"] }

--- a/src/minute.rs
+++ b/src/minute.rs
@@ -1,5 +1,4 @@
-use anyhow::{bail, Context, Result};
-use rand::seq::SliceRandom;
+use anyhow::{bail, Result};
 
 pub struct Minute<'a> {
     pub title: &'a str,
@@ -14,9 +13,14 @@ include!(concat!(env!("OUT_DIR"), "/quotes.rs"));
 pub fn get_minute<'a>(time: &str, sfw: bool) -> Result<&'a Minute> {
     let options = include!(concat!(env!("OUT_DIR"), "/options.rs"));
 
-    let quote = options
-        .choose(&mut rand::thread_rng())
-        .context("Unable to choose a random quote")?;
+    match options.len() {
+        1 => Ok(options[0]),
+        l => {
+            // Use the current millisecond fraction as a pseudo random picker
+            let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?;
+            let millis = now.subsec_millis() as usize;
 
-    Ok(quote)
+            Ok(options[millis % l])
+        }
+    }
 }


### PR DESCRIPTION
It's a minor thing, but no need to use `rand` for just picking a quote out of options, when we can just use something like the current millisecond from SystemTime