### PR TITLE
Use termcolor to render color 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
+        env:
+          TERM: xterm
         with:
           command: test
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "termcolor",
  "termsize",
  "textwrap",
  "time",
@@ -304,6 +305,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +415,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4", features = ["derive"] }
 termsize = "0.1"
 time = { version = "0.3", default-features = false, features = ["local-offset", "parsing"] }
 anyhow = "1"
+termcolor = "1.3.0"
 
 [profile.release]
 codegen-units = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,2 @@
 pub mod formatter;
-#[rustfmt::skip]
 pub mod minute;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,9 @@ static MARGIN: usize = 5; // Margin on the right of the comment, only used when 
 
 /// Hello
 #[derive(Parser, Debug)]
-#[command(version, about=r#"A command line tool to dispaly the current time-ish with a literature quote.
+#[command(
+    version,
+    about = r#"A command line tool to dispaly the current time-ish with a literature quote.
 
 Parts of the quote can be formatted with formatting strings, in the form of '<style> <colour>' or just '<colour>'
 Available colours are:
@@ -23,7 +25,8 @@ Available colours are:
 Available styles are:
 
     bold, dimmed, intense, italic, strikethrough and underline 
-"#)]
+"#
+)]
 struct Args {
     /// A timestamp to get a quote for
     ///
@@ -89,12 +92,15 @@ fn main() -> Result<()> {
             .unwrap_or(DEFAULT_WIDTH)
     });
 
-    minute.formatted(
-        std::cmp::max(width, MIN_WIDTH),
-        &args.main_formatting,
-        &args.time_formatting,
-        &args.author_formatting,
-    )?;
+    println!(
+        "{}",
+        minute.formatted(
+            std::cmp::max(width, MIN_WIDTH),
+            &args.main_formatting,
+            &args.time_formatting,
+            &args.author_formatting,
+        )?
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Closes #43 

Introduces another breaking change unfortunately, as it changes the formatting slightly by removing `bright-` from all the colours.

Confirmed working with base colours on Windows, but styles do nothing. Assuming a limitation on the Windows side?