### PR TITLE
Use https instead of ssh for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/literature-clock"]
 	path = external/literature-clock
-	url = git@github.com:JohannesNE/literature-clock
+  url = https://github.com/JohannesNE/literature-clock.git


### PR DESCRIPTION
I _believe_ this should let you install with brew without having an ssh key set up